### PR TITLE
Allow overwriting the default host

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.1.3",
 	"scripts": {
 		"start": "run-p server watch",
-		"server": "serve --cache 0 --port 4002",
+		"server": "NODE_ENV=development serve --cache 0 --port 4002",
 		"watch": "NODE_ENV=development rollup --config --watch",
 		"build": "NODE_ENV=production rollup --config && npm run build-minify",
 		"build-minify": "babili dist/radio4000-player.js > dist/radio4000-player.min.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "0.1.3",
 	"scripts": {
 		"start": "run-p server watch",
-		"server": "NODE_ENV=development serve --cache 0 --port 4002",
+		"server": "serve --cache 0 --port 4002",
 		"watch": "NODE_ENV=development rollup --config --watch",
 		"build": "NODE_ENV=production rollup --config && npm run build-minify",
 		"build-minify": "babili dist/radio4000-player.js > dist/radio4000-player.min.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ export default {
 		commonjs(),
 		replace({
 			// See https://vuejs.org/v2/guide/deployment.html#With-Build-Tools
-			'process.env.NODE_ENV': JSON.stringify('production')
+			'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
 		}),
 		// Do not rely on node utils in browser environment.
 		// nodeBuiltins()

--- a/src/store.js
+++ b/src/store.js
@@ -3,7 +3,7 @@ import fetch from 'unfetch'
 let host = 'https://radio4000.firebaseio.com'
 
 // Allow overwriting the default host.
-if (window.r4.databaseURL) {
+if (window.r4 && window.r4.databaseURL) {
 	host = window.r4.databaseURL
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -1,15 +1,17 @@
 import fetch from 'unfetch'
 
-
-let host = 'https://radio4000-staging.firebaseio.com'
-
-if (process.env.NODE_ENV = 'production') {
-	host = 'https://radio4000.firebaseio.com'
+// Prioritze the host from R4, then production, then staging.
+const getHost = () => {
+	if (window && window.r4 && window.r4.databaseURL) {
+		return window.r4.databaseURL
+	}
+	if (process.env.NODE_ENV === 'production') {
+		return 'https://radio4000.firebaseio.com'
+	}
+	return 'https://radio4000-staging.firebaseio.com'
 }
 
-if (window.r4 && window.r4.databaseURL) {
-	host = window.r4.databaseURL
-}
+const host = getHost()
 
 // Utilities for working with Firebase REST API.
 const parse = res => res.json()

--- a/src/store.js
+++ b/src/store.js
@@ -1,14 +1,14 @@
 import fetch from 'unfetch'
 
-let host = 'https://radio4000.firebaseio.com'
 
-// Allow overwriting the default host.
-if (window.r4 && window.r4.databaseURL) {
-	host = window.r4.databaseURL
+let host = 'https://radio4000-staging.firebaseio.com'
+
+if (process.env.NODE_ENV = 'production') {
+	host = 'https://radio4000.firebaseio.com'
 }
 
-if (process.env.NODE_ENV = 'development') {
-	host = 'https://radio4000-staging.firebaseio.com'
+if (window.r4 && window.r4.databaseURL) {
+	host = window.r4.databaseURL
 }
 
 // Utilities for working with Firebase REST API.

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,10 @@ if (window.r4 && window.r4.databaseURL) {
 	host = window.r4.databaseURL
 }
 
+if (process.env.NODE_ENV = 'development') {
+	host = 'https://radio4000-staging.firebaseio.com'
+}
+
 // Utilities for working with Firebase REST API.
 const parse = res => res.json()
 const serializeId = (data, id) => Object.assign(data, {id})

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,11 @@
 import fetch from 'unfetch'
 
-const host = 'https://radio4000.firebaseio.com'
+let host = 'https://radio4000.firebaseio.com'
+
+// Allow overwriting the default host.
+if (window.r4.databaseURL) {
+	host = window.r4.databaseURL
+}
 
 // Utilities for working with Firebase REST API.
 const parse = res => res.json()


### PR DESCRIPTION
This is useful on Radio4000 where we work with staging and live databases.

In Radio4000 we would then do the following in app.js

```js
window.r4 = {}
window.r4.databaseURL = config.firebase.databaseURL
```

Needs https://github.com/internet4000/radio4000/pull/46