### PR TITLE
Fix test setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,11 @@
 {
-  "presets": [
-    ["env", {
+	"presets": [
+		["env", {
 			"modules": false,
-      "targets": {
-        "browsers": ["last 2 versions", "safari >= 7"]
-      }
-    }]
-  ],
-  "plugins": [
-    "external-helpers"
-  ]
+				"targets": {
+					"browsers": ["last 2 versions", "safari >= 7"]
+				}
+		}]
+	]
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,7 @@ import vue from 'rollup-plugin-vue'
 
 export default {
 	entry: 'src/main.js',
+	dest: 'dist/radio4000-player.js',
 	// We want UMD so it works in the browser and node.
 	format: 'umd',
 	moduleName: 'radio4000player',
@@ -37,8 +38,8 @@ export default {
 		nodeGlobals(),
 		// Transpile ES6 (and more) to ES5 code. Also see the .babelrc file.
 		babel({
-			exclude: 'node_modules/**'
+			exclude: 'node_modules/**',
+			plugins:['external-helpers']
 		})
-	],
-	dest: 'dist/radio4000-player.js'
+	]
 }


### PR DESCRIPTION
After adding rollup-plugin-babel and external-helper plugin,
tests wouldn't run. Moving the plugin from .babelrc to rollup
config seems to solve it.

Waiting to see if it also works on Travis.