### PR TITLE
Track list and controls styling

### DIFF
--- a/src/PlayPauseButton.vue
+++ b/src/PlayPauseButton.vue
@@ -18,8 +18,13 @@ export default {
 		uid() {
 			return `id${this._uid}`
 		},
-		playing() {
-			return this.$props.isPlaying
+		playing: {
+			get: function () {
+				return this.$props.isPlaying
+			},
+			set: function () {
+				// catch it to avoid a Vue warning
+			}
 		}
 	},
 	methods: {

--- a/src/PlayPauseButton.vue
+++ b/src/PlayPauseButton.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="PlayPause">
 		<input type="checkbox" :id="uid" class="PlayPause-state"
-			v-model="playing" @change="toggle" />
+			:checked="isPlaying" @change="toggle" />
 		<label :for="uid" :title="isPlaying ? 'Pause' : 'Play'" class="PlayPause-label">
 			<div class="PlayPause-controller"></div>
 		</label>
@@ -17,14 +17,6 @@ export default {
 	computed: {
 		uid() {
 			return `id${this._uid}`
-		},
-		playing: {
-			get: function () {
-				return this.$props.isPlaying
-			},
-			set: function () {
-				// catch it to avoid a Vue warning
-			}
 		}
 	},
 	methods: {

--- a/src/PlayPauseButton.vue
+++ b/src/PlayPauseButton.vue
@@ -2,7 +2,7 @@
 	<div class="PlayPause">
 		<input type="checkbox" :id="uid" class="PlayPause-state"
 			v-model="playing" @change="toggle" />
-		<label :for="uid" title="Play/pause" class="PlayPause-label">
+		<label :for="uid" :title="isPlaying ? 'Pause' : 'Play'" class="PlayPause-label">
 			<div class="PlayPause-controller"></div>
 		</label>
 	</div>

--- a/src/PlayerControls.vue
+++ b/src/PlayerControls.vue
@@ -14,14 +14,14 @@
 		<div class="PlayerControl-group">
 			<button title="Shuffle tracks (on/off)"
 				class="Btn Btn--shuffle"
-				:class="{ 'is-active' : !isShuffle }"
+				:class="{ 'is-active' : isShuffle }"
 				:disabled="isDisabled"
 				@click="$emit('toggleShuffle')">
 				<span>↝</span>
 			</button>
 		</div>
 		<div class="PlayerControl-group PlayerControl-group--large">
-			<PlayPauseButton title="Play/pause"
+			<PlayPauseButton 
 				class="Btn"
 				:isPlaying="isPlaying"
 				@play="$emit('play')"
@@ -60,6 +60,7 @@ export default {
 <style scoped>
 	.PlayerControl {
 		min-height: 2.5em;
+		background: hsl(0, 0%, 96%);
 	}
 	.PlayerControl {
 		border-top: 1px solid hsl(0, 0%, 70%);
@@ -78,10 +79,11 @@ export default {
 	}
 	.Btn {
 		width: 100%;
+		padding: 0 0.5rem;
+		font-size: 0.8em;
+		line-height: 1;
 		background: hsl(0, 0%, 96%);
 		border: 0;
-		font-size: 0.8125em; /* 13/16 */
-		padding: 0.2em 0.5em 0.1em;
 	}
 	.Btn--isNotFullVolume span {
 		opacity: 0.4;
@@ -92,19 +94,19 @@ export default {
 	.Btn--mute.is-active span::before {
 		content: '□';
 	}
-	.PlayPause,
 	.Btn--shuffle {
-		padding-top: 0;
-		padding-bottom: 0;
+		font-size: 2em;
 	}
-	.Btn--next span,
 	.Btn--shuffle span {
-		font-size: 1.7em;
-	}
-	.Btn--shuffle {
-		line-height: 1;
+		position: relative;
+		top: -0.05em;
+		opacity: 0.5;
 	}
 	.Btn--shuffle.is-active span {
-		opacity: 0.5;
+		opacity: 1;
+	}
+	.PlayPause {}
+	.Btn--next {
+		font-size: 1.5em;
 	}
 </style>

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -195,6 +195,9 @@ radio4000-player {
 	background-color: hsl(260, 10%, 92%);
 	color: hsl(0, 0%, 10%);
 	font-size: 16px;
+}
+radio4000-player,
+radio4000-player .Btn {
 	font-family: 'Maison Neue', 'maisonneue', 'system-ui', sans-serif;
 }
 </style>

--- a/src/TrackItem.vue
+++ b/src/TrackItem.vue
@@ -20,7 +20,7 @@ export default {
 <style scoped>
 	.TrackItem {
 		width: 100%;
-		padding: 0.5em 0.6em;
+		padding: 0.4em 0.6em;
 		cursor: pointer;
 	}
 	.TrackItem-title,
@@ -33,8 +33,7 @@ export default {
 	.TrackItem-title {
 		display: inline-block; /* for .active styles */
 		font-size: 0.8125em; /* 13/16 */
-		line-height: 1.5;
-		margin-bottom: 0.1em;
+		line-height: 1.4;
 	}
 	.TrackItem-body {
 		font-size: 0.75em; /* 12/16 */

--- a/src/TrackItem.vue
+++ b/src/TrackItem.vue
@@ -19,40 +19,33 @@ export default {
 
 <style scoped>
 	.TrackItem {
-		cursor: pointer;
-		display: block;
 		width: 100%;
-		padding-bottom: 0.3em;
-		padding-left: 0.6em;
+		padding: 0.5em 0.6em;
+		cursor: pointer;
 	}
 	.TrackItem-title,
 	.TrackItem-body {
+		margin: 0;
+		padding-left: 0.3em;
+		padding-right: 0.3em;
 		word-break: break-word;
-		line-height: 1.2;
-		margin-top: 0;
-		margin-bottom: 0;
 	}
 	.TrackItem-title {
-		padding: 0.2rem 0.3em;
-		float: left;
+		display: inline-block; /* for .active styles */
+		font-size: 0.8125em; /* 13/16 */
+		line-height: 1.5;
+		margin-bottom: 0.1em;
 	}
 	.TrackItem-body {
-		display: block;
-		clear: both;
-		margin-left: 0.4em;
-		border-left: 1px solid #cecece;
-		padding-top: 0.1em;
-		padding-left: 0.4em;
-		margin-bottom: 0.3em;
-		font-style: italic;
+		font-size: 0.75em; /* 12/16 */
 		color: #737373;
+	}
+	.TrackItem:hover,
+	.TrackItem.active {
+		background-color: hsla(0, 0%, 100%, 0.2);
 	}
 	.TrackItem.active .TrackItem-title {
 		background-color: #5e1ae6;
 		color: white;
-	}
-	.TrackItem.active .TrackItem-body {
-		border-left-color: #5e1ae6;
-		transition: 200ms border-left-color cubic-bezier(0.55, 0.09, 0.68, 0.53);
 	}
 </style>

--- a/src/TrackList.vue
+++ b/src/TrackList.vue
@@ -62,22 +62,20 @@ export default {
 		transform: translateZ(0);
 	}
 	.TrackList-item {
-		font-size: 0.8125em; /* 13/16 */
-		padding-right: 0.6em;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		align-items: center;
+		position: relative;
+		border-bottom: 1px solid #e0e0e0;
 	}
-	.TrackList-item:first-child {
-		padding-top: 0.6em;
+	.TrackList-item:last-child {
+		border-bottom: 0;
 	}
 	.TrackList-item::after {
 		content: counter(tracks) "";
 		counter-increment: tracks;
 		color: #737373;
-		font-size: 0.6em;
-		padding-left: 0.4em;
+		font-size: 0.5em;
+		position: absolute;
+		top: 0.5em;
+		right: 0.5em;
 	}
 	.TrackList-controls {
 		position: absolute;


### PR DESCRIPTION
#82 Hi, this styles the tracklist and controls at the bottom a bit.

- style the tracklist more like radio4000.com. With a border in between to better seperate the tracks
- tweak icons so they are more the same size (shuffle was very small)

Here's a screen of the updated tracklist

![screen shot 2017-09-24 at 13 08 44](https://user-images.githubusercontent.com/184567/30781976-912fa86a-a129-11e7-8007-ae2eb93fd5fc.png)