### PR TITLE
Move query prop to playlist/channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ var vue = player.__vue_custom_element__.$children[0]
 vue.updatePlaylist(playlist)
 ```
 
+If the playlist object contains a `query` string it will be shown on top of the track list.
+
 ## Using internal links
 
 If this player is used inside radio4000.com, we want the links to switch URL internally.

--- a/cypress/integration/track-list.js
+++ b/cypress/integration/track-list.js
@@ -27,4 +27,12 @@ describe('<TrackList> component', function() {
 			assert.equal(wrapper.findAll('.TrackItem-title').wrappers[2].element.textContent, 'c')
 		})
 	})
+
+	it('shows query message if supplied', function() {
+		assert.isNotOk(wrapper.find('.TrackList-query').element)
+		wrapper.vm.$props.query = '#jazz #funk'
+		return cy.wait(10).then(() => {
+			assert.isOk(wrapper.find('.TrackList-query').element)
+		})
+	})
 })

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 	<!-- <radio4000-player channel-id="-KFzPXLNzmKjPGwyY-xx"></radio4000-player> -->
 
 	<!-- tests -->
-	<!-- <radio4000-player channel-slug="200ok" query="funk 1970"></radio4000-player> -->
 	<!-- <radio4000-player channel-slug="200ok" autoplay="true"></radio4000-player> -->
 	<!-- <radio4000-player channel-slug="200ok" shuffle="true"></radio4000-player> -->
 

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -132,7 +132,7 @@
 			loadChannelImage(channel) {
 				findChannelImage(channel)
 					.then(this.updateImage)
-					.catch(err => {console.log(err)})
+					// .catch(err => {console.log(err)})
 			},
 
 			/*

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -120,7 +120,17 @@
 				return findTrack(id)
 					.then(track => {
 						this.track = track
-						if (this.channel.id === track.channel) return
+
+						// don't refresh
+						const hasQuery = this.channel.query
+						const sameChannel = this.channel.id === track.channel
+						const trackAlreadyLoaded = this.tracks.filterBy('id', id).length === 1
+						// console.log({hasQuery, sameChannel, trackAlreadyLoaded})
+						if (sameChannel && hasQuery && trackAlreadyLoaded || sameChannel && !hasQuery) {
+							return
+						}
+
+						// refresh
 						return this.loadChannelById(track.channel)
 					})
 			},

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -9,7 +9,6 @@
 		:r4Url="r4Url"
 		:volume="localVolume"
 		:shuffle="shuffle"
-		:query="query"
 		@trackChanged="onTrackChanged"
 		@trackEnded="onTrackEnded">
 	</radio4000-player>
@@ -47,8 +46,7 @@
 				type: Number,
 				default: 100
 			},
-			shuffle: Boolean,
-			query: String
+			shuffle: Boolean
 		},
 		data () {
 			return {

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -25,7 +25,7 @@
 					:channelSlug="channel.slug"
 					:track="currentTrack"
 					:tracks="tracksPool"
-					:query="query"
+					:query="channel.query"
 					@select="playTrack"></track-list>
 			</div>
 		</div>


### PR DESCRIPTION
Move top-level `query="#jazz"` API to be on the channel/playlist object. This way it's a lot easier to maintain.

Requires https://github.com/internet4000/radio4000/pull/185
Comes from https://github.com/internet4000/radio4000/issues/180