### PR TITLE
Avoid fetching track twice

### DIFF
--- a/cypress/integration/player-data.js
+++ b/cypress/integration/player-data.js
@@ -10,4 +10,14 @@ describe('<PlayerData> component', function() {
 			cy.get('.Header-channel').should('contain', 'Radio Oskar')
 		})
 	})
+
+	it('and it can change radio again via track id', function() {
+		cy.get('radio4000-player').should('have.attr', 'channel-slug', '200ok')
+		cy.get('radio4000-player').then($player => {
+			$player.attr('track-id', '-JYZuBhe3ep1KxlOO4j1')
+			cy.get('.Header-channel').should('contain', 'Radio Maretto')
+			// $player.attr('track-id', '-KBGMjlqb7FnsHqcZn0u')
+			// cy.get('.Header-channel').should('contain', 'Good Time Radio')
+		})
+	})
 })

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -114,7 +114,7 @@
 			},
 			loadChannelByTrack(id) {
 				// avoid loading track twice
-				let track = this.tracks && this.tracks.filter(t => t.id === id)[0]
+				let track = this.tracks && this.tracks.find(t => t.id === id)
 				if (track) {
 					return this.track = track
 				}

--- a/src/PlayerData.vue
+++ b/src/PlayerData.vue
@@ -113,16 +113,19 @@
 					.catch(err => {console.log(err)})
 			},
 			loadChannelByTrack(id) {
-				return findTrack(id)
-					.then(track => {
+				// avoid loading track twice
+				let track = this.tracks && this.tracks.filter(t => t.id === id)[0]
+				if (track) {
+					return this.track = track
+				}
+
+				return findTrack(id).then(track => {
 						this.track = track
 
-						// don't refresh
+						// avoid loading the same channel twice
 						const hasQuery = this.channel.query
 						const sameChannel = this.channel.id === track.channel
-						const trackAlreadyLoaded = this.tracks.filterBy('id', id).length === 1
-						// console.log({hasQuery, sameChannel, trackAlreadyLoaded})
-						if (sameChannel && hasQuery && trackAlreadyLoaded || sameChannel && !hasQuery) {
+						if (sameChannel && hasQuery || sameChannel && !hasQuery) {
 							return
 						}
 
@@ -138,7 +141,7 @@
 			loadChannelImage(channel) {
 				findChannelImage(channel)
 					.then(this.updateImage)
-					// .catch(err => {console.log(err)})
+					// no catch because no image is ok
 			},
 
 			/*


### PR DESCRIPTION
Brief summary:

- When you tap a track in `<radio4000-player>`, the track is instantly switched and no requests are made via internal `play` method.

- When you tap a track on radio4000.com, we set `track-id` as attribute which triggers `loadChannelByTrack`. This method would _always_ request the track via the id.

This PR changes that behaviour. It checks if the track is already loaded e.g. exists in `this.tracks` and returns early to avoid extra requests. Tested in locally on R4 and it feels much faster to me!