### PR TITLE
Don't fetch images, but set URL from image id

### DIFF
--- a/src/FetchData.vue
+++ b/src/FetchData.vue
@@ -5,8 +5,8 @@
 		findChannelById,
 		findChannelBySlug,
 		findChannelTracks,
-		findChannelImage,
-		findTrack
+		findTrack,
+		buildThumbnail
 	} from './utils/store'
 
 	export default {
@@ -74,19 +74,12 @@
 					.then(tracks => this.update({tracks}))
 					.catch(err => {console.log(err)})
 			},
-			loadChannelImage(channel) {
-				findChannelImage(channel)
-					.then(image => this.update({image}))
-					.catch(() => this.update({image}))
-			},
 			loadTracksAndImageFromChannel(channel) {
 				// Reset tracks and image to show loading UX immediately.
 				this.update({tracks: [], image: ''})
 
 				if (channel.image) {
-					this.update({image: channel.image})
-				} else {
-					this.loadChannelImage(channel)
+					this.update({image: buildThumbnail(channel.image)})
 				}
 
 				if (channel.tracks.length) {

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -51,6 +51,6 @@ export function findTrack(id) {
 }
 
 export function buildThumbnail(cloudinaryId) {
-	return `https://res.cloudinary.com/radio4000/image/upload/q_auto,w_56,h_56,c_thumb,c_fill,fl_lossy/${cloudinaryId}`
+	return `https://res.cloudinary.com/radio4000/image/upload/w_120,h_120,q_60,c_thumb,fl_lossy/${cloudinaryId}`
 }
 

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -50,12 +50,7 @@ export function findTrack(id) {
 	return fetch(url).then(parse).then(data => serializeId(data, id))
 }
 
-export function findChannelImage(channel) {
-	if (!channel || !channel.images) return Promise.reject()
-	const url = `${host}/images.json?orderBy="channel"&startAt="${channel.id}"&endAt="${channel.id}"&limitToLast=1`
-	return fetch(url).then(parse).then(toArray).then(getFirst).then(img => {
-		const rootURL = 'https://res.cloudinary.com/radio4000/image/upload/'
-		const transforms = `q_100,w_56,h_56,c_thumb,c_fill,fl_lossy`
-		return `${rootURL}/${transforms}/${img.src}`
-	})
+export function buildThumbnail(cloudinaryId) {
+	return `https://res.cloudinary.com/radio4000/image/upload/q_auto,w_56,h_56,c_thumb,c_fill,fl_lossy/${cloudinaryId}`
 }
+


### PR DESCRIPTION
Closes #124.

All loading methods (by channel id, slug and track id), we expect a Cloudinary ID and build the thumbnail in the player.

Note, the exception is `updatePlaylist`, where we expect a full image URL.

Once this is released, the player won't recognize or use `channel.images` in any way.