### PR TITLE
Remove removeEventListener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,5 @@ Vue.customElement('radio4000-player', Radio4000Player, {
 
 		// Catch the internal ready event and emit our own event.
 		this.addEventListener('vce-ready', dispatchReadyEvent)
-	},
-
-	disconnectedCallback() {
-		this.removeEventListener('vce-ready')
 	}
 })


### PR DESCRIPTION
Since the event is attached to the element itself, it should not be necessary to remove it. 

When testing the element inside Radio4000, it would otherwise cause an error.