### PR TITLE
Possible autoplay fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@
 					url: 'https://www.youtube.com/watch?v=OkR7UNnQU6c'
 				},
 				{
+					title: '404 youtube link',
+					url: 'https://www.youtube.com/watch?v=SUPERKAFADSA'
+				},
+				{
 					title: 'black focus youtube',
 					url: 'https://www.youtube.com/watch?v=4D8YPDdsxYU'
 				},
@@ -96,7 +100,7 @@
 		<!-- <radio4000-player track-id="-JyCMmQETox_SF6-x6Tr"></radio4000-player> -->
 
 		<!-- media is a local audio file-player -->
-		<radio4000-player id="playlist-player" autoplay="true"></radio4000-player>
+		<radio4000-player id="playlist-player" autoplay></radio4000-player>
 		<!-- <radio4000-player id="playlist-player"></radio4000-player> -->
 
 		<script>

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -247,7 +247,7 @@
 				this.track = track
 				// force play when asking to play a track
 				// also solves mediaNotAvailable putting pause
-				this.autoplay && this.play()
+				if (this.isPlaying || this.autoplay) this.play()
 				this.$emit('trackChanged', {
 					track, previousTrack
 				})

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -242,16 +242,6 @@
 					this.tracksPool = pool
 				}
 			},
-			playTrack(track) {
-				const previousTrack = this.track
-				this.track = track
-				// force play when asking to play a track
-				// also solves mediaNotAvailable putting pause
-				if (this.isPlaying || this.autoplay) this.play()
-				this.$emit('trackChanged', {
-					track, previousTrack
-				})
-			},
 			playNextTrack() {
 				const track = this.getNextTrack()
 				if (!track) return
@@ -261,6 +251,20 @@
 				const pool = this.tracksPool
 				const index = this.currentTrackIndex
 				return pool[index + 1]
+			},
+			playTrack(track) {
+				const previousTrack = this.track
+				this.track = track
+
+				// force play when asking to play a track
+				// also solves mediaNotAvailable putting pause
+				if (this.isPlaying || this.autoplay) {
+					this.play()
+				}
+
+				this.$emit('trackChanged', {
+					track, previousTrack
+				})
 			},
 			play() {
 				this.isPlaying = true
@@ -309,6 +313,11 @@
 				this.$emit('mediaNotAvailable', {
 					track: this.track
 				})
+
+				// When not available, player pauses.
+				// Here we set it back to true, for continuous play.
+				this.isPlaying = true 
+
 				this.trackEnded()					
 			}
 		}

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -247,7 +247,7 @@
 				this.track = track
 				// force play when asking to play a track
 				// also solves mediaNotAvailable putting pause
-				this.play()
+				this.autoplay && this.play()
 				this.$emit('trackChanged', {
 					track, previousTrack
 				})


### PR DESCRIPTION
When the player is playing from an R4 channel, it'll always autoplay, even when disabled. This is an attempt to fix it, so it only autoplays when the attribute is there.