### PR TITLE
add the possibility of fullscreen via hidding the elements of the player

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,31 @@ OR, you can use an iframe ([source](https://github.com/internet4000/radio4000-ap
 
 Here's a complete list of all the attributes you can set and change on the web component. These do not affect the iframe version.
 
-|Attribute|Type|Description|
-|----|----|----|
-|channel-slug|`string`|Radio4000 channel slug (ex: `oskar`)
-|channel-id|`string`|Radio4000 channel id (ex: `-JYZvhj3vlGCjKXZ2cXO`)
-|track-id|`string`|Radio4000 track id (ex: `-JYEosmvT82Ju0vcSHVP`)
-|volume|`integer`|from 0 to 100 (default: `100`)
-|autoplay|`boolean`|if it should start playing automatically (default: `false`)
-|shuffle|`boolean`|if tracks should be shuffled (default: `false`)
-|r4-url|`boolean`|use relative, internal links. When the player is used on radio4000.com we want the links to not open a new window. (default: `false`)
+| Attribute     | Type              | Description                                                                                                       |
+|---------------|-------------------|-------------------------------------------------------------------------------------------------------------------|
+| channel-slug  | `string`          | Radio4000 channel slug (ex: `oskar`)                                                                              |
+| channel-id    | `string`          | Radio4000 channel id (ex: `-JYZvhj3vlGCjKXZ2cXO`)                                                                 |
+| track-id      | `string`          | Radio4000 track id (ex: `-JYEosmvT82Ju0vcSHVP`)                                                                   |
+| volume        | `integer`         | from 0 to 100 (default: `100`)                                                                                    |
+| autoplay      | `boolean` [false] | if it should start playing automatically, if `volume` is set to `0`. See note.                                                                          |
+| shuffle       | `boolean` [false] | if tracks should be shuffled                                                                                      |
+| r4-url        | `boolean` [false] | use relative, internal links. When the player is used on radio4000.com we want the links to not open a new window |
+| showHeader    | `boolean` [false] | Display or not the header part of the player. Where the channel image and current track are displayed             |
+| showTrackList | `boolean` [false] | Display or not the player's list of tracks                                                                        |
+| showControls  | `boolean` [false] | Display or not the player's controls. Where the play, mute and next buttons are                                   |
+
+Note: If you change `showTrackList` `showControls` `showHeader`, to
+`true`, you will have the effect of a fullscreen mode for the
+player. In which only the media is displayed. Mostly usefull for a tv
+effect, to easily display a channel on a website, for example as a
+animated background. See `autoplay`.
+
+Note: To have `autoplay` working, you should also set the `volume`
+property to `0`. It has for effect of muting the autio of all media
+played in the player, and this is required for the autoplay feature to
+work. This requirement is enforced by browsers (Firefox, Chromium,
+etc.), so the User Experience forbits video to be autoplayed on
+websites, if there is also audio.
 
 ### Examples
 

--- a/index.html
+++ b/index.html
@@ -98,7 +98,6 @@
 		<!-- media is a local audio file-player -->
 		<radio4000-player id="playlist-player" autoplay="true"></radio4000-player>
 		<!-- <radio4000-player id="playlist-player"></radio4000-player> -->
-
 		<script>
 
 			/* 

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="Layout" v-if="canLoad">
+	<div class="Layout" v-if="canLoad" :class="{ isShowHeader: showHeader, isShowTrackList: showTrackList, isShowControls: showControls }">
 		<FetchData
 			v-if="isOnline"
 			:channelId="channelId"
@@ -84,20 +84,39 @@
 
 		// Top level properties are also exposed as attributes on the web component.
 		props: {
+			/* data */
 			channelSlug: String,
 			channelId: String,
 			trackId: String,
-			autoplay: Boolean,
 			r4Url: {
 				type: Boolean,
 				default: false
 			},
+			query: String,
+
+			/* player behavior */
+			autoplay: Boolean,
+			shuffle: Boolean,
 			volume: {
 				type: Number,
 				default: 100
 			},
-			shuffle: Boolean,
-			query: String
+			
+			/* ui */
+			/* we always show media; youtube terms. */
+			/* when all are activated, media is fullscreen */
+			showHeader: {
+				type: Boolean,
+				default: true
+			},
+			showTrackList: {
+				type: Boolean,
+				default: true
+			},
+			showControls: {
+				type: Boolean,
+				default: true
+			}		
 		},
 
 		data () {
@@ -367,6 +386,12 @@
 		flex-direction: column;
 		overflow: hidden;
 		border: 1px solid hsl(0, 0%, 70%);
+	}
+	/* themes given by js classes and r4 props */
+	.Layout:not(.isShowHeader) .Layout-header,
+	.Layout:not(.isShowTrackList) .Layout-main,
+	.Layout:not(.isShowControls) .Layout-footer {
+		display: none
 	}
 
 	.Layout-header {


### PR DESCRIPTION
small PR to let the possibility of having a `fullscreen` mode.

It hides the other elements, such as the tracklist, the channel, the controls.

It is made so it is possible to hide each part independently, and build your "own version" of the player where you embed it. A combination of all gives the fullscreen mode (on the player's dimensions. The rest of the screen has to be coded by the devs themselves, even though we could has a `allow-fullscreen` property, to show a browser's fullscreen button/effect).

It adds 3 new props on the `radio4000-player` component:
`show-controls="false"`, will hide the player control part.
Similar behavior for `show-header`, `show-track-list`.
They all default to `true`.

Everything else is achieved through css, to hide the elements. Nothing else had to be added as the `ProviderPlayer` child components are already well fluid for all providers