### PR TITLE
fix autoplay from loading tracks

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 		<!-- <radio4000-player track-id="-JyCMmQETox_SF6-x6Tr"></radio4000-player> -->
 
 		<!-- media is a local audio file-player -->
-		<radio4000-player id="playlist-player" autoplay="true"></radio4000-player>
+		<radio4000-player id="playlist-player" autoplay="false"></radio4000-player>
 		<!-- <radio4000-player id="playlist-player"></radio4000-player> -->
 
 		<script>

--- a/src/FilePlayer.vue
+++ b/src/FilePlayer.vue
@@ -82,7 +82,8 @@
 				this.$emit('paused')
 			},
 			handlePlay() {
-				if (this.isPlaying) {
+				const isPlaying = this.isPlaying
+				if (isPlaying) {
 					this.$emit('playing')
 				}
 			},

--- a/src/ProviderPlayer.vue
+++ b/src/ProviderPlayer.vue
@@ -1,6 +1,5 @@
 <template>
 	<div class="ProviderPlayer" :class="{'ProviderPlayer--file': provider === 'file'}">
-
 		<file-player
 			v-if="provider === 'file'"
 			:url="track.url"

--- a/src/Radio4000Player.vue
+++ b/src/Radio4000Player.vue
@@ -178,7 +178,11 @@
 				this.newTracksPool()
 				const noTrack = Object.keys(this.track).length === 0
 				if (noTrack) {
-					this.playNextTrack()
+					if ( this.isPlaying) {
+						this.playNextTrack()
+					} else {
+						this.loadNextTrack()
+					}
 				}
 			}
 		},
@@ -242,20 +246,28 @@
 					this.tracksPool = pool
 				}
 			},
-			playTrack(track) {
+			loadTrack(track) {
 				const previousTrack = this.track
 				this.track = track
-				// force play when asking to play a track
-				// also solves mediaNotAvailable putting pause
-				this.play()
 				this.$emit('trackChanged', {
 					track, previousTrack
 				})
+			},
+			playTrack(track) {
+				this.loadTrack(track)
+				// force play when asking to play a track
+				// also solves mediaNotAvailable putting pause
+				this.play()
 			},
 			playNextTrack() {
 				const track = this.getNextTrack()
 				if (!track) return
 				this.playTrack(track)
+			},
+			loadNextTrack() {
+				const track = this.getNextTrack()
+				if (!track) return
+				this.loadTrack(track)
 			},
 			getNextTrack() {
 				const pool = this.tracksPool


### PR DESCRIPTION
Should fix the autoplay function of the player.

Issue was that loading track was calling playNext, which was handling the loading of the first track, and the next ones.

Added a loadTrack method, so now there is a separation of what these are doing