### PR TITLE
add docker and docker-compose files to use node.js 16 (hard dep)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY src ./src/
 RUN npm install
 
 # Expose the port on which the frontend server runs
-EXPOSE 4002
+EXPOSE 4000
 
 # Command to start the development server
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 # Copy application logic to the container
 COPY package*.json ./
 COPY index.html ./
+COPY poi.config.js ./
 
 # shadowed as volumes by compose
 COPY src ./src/
@@ -15,7 +16,7 @@ COPY src ./src/
 RUN npm install
 
 # Expose the port on which the frontend server runs
-EXPOSE 4000
+EXPOSE 4002
 
 # Command to start the development server
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use node image as base
+FROM node:16
+
+# Set working directory in the container
+WORKDIR /app
+
+# Copy application logic to the container
+COPY package*.json ./
+COPY index.html ./
+
+# shadowed as volumes by compose
+COPY src ./src/
+
+# Install dependencies
+RUN npm install
+
+# Expose the port on which the frontend server runs
+EXPOSE 4002
+
+# Command to start the development server
+CMD ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -244,3 +244,16 @@ Running this command create a new, tagged "release" commit including a productio
 
 The `./demo/index.html` file will be deployed to player.radio4000.com via Netlify.
 
+### With docker and doker-compose
+Run `docker-compose up` to start a local server and `down` to stop it;
+`build` will re-build a new images for changes made outside of the
+`src` folder.
+
+See `docker-compose.yml` and `Dockerfile`.
+
+With docker compose, the folder `./src` is mounted as a volume, to the container is used
+only for the node version 16 required by the project, and changes
+should be reflected in the live server.
+
+With solely docker, re-build for every change, and re-run the image to
+see them on local server (run inside docker).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: radio4000-player-vue
+    hostname: radio4000-player-vue
+    ports:
+      - "4002:4002"
+    volumes:
+      - ./src:/app/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     container_name: radio4000-player-vue
     hostname: radio4000-player-vue
     ports:
-      - "4000:4000"
+      - "4000:4002"
     volumes:
       - ./src:/app/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     container_name: radio4000-player-vue
     hostname: radio4000-player-vue
     ports:
-      - "4002:4002"
+      - "4000:4000"
     volumes:
       - ./src:/app/src

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@vue/test-utils": "^1.0.0-beta.29",
     "cypress": "^6.5.0",
     "poi": "^12.10.3",
+    "webpack": "^4.0.0",
     "release-it": "^14.12.5",
     "start-server-and-test": "^1.9.1",
     "vue-template-compiler": "^2.6.10"


### PR DESCRIPTION
because the project needs node version 16, and some system cannot install this version (or `nvm`; or users on these systems), maybe docker and compose can help.

See the readme for usage.